### PR TITLE
[iOS8Upgrades - Scroll Issues] Fixed scroll issues by turning off "au…

### DIFF
--- a/Example/UPEmbeddedTextViewManager/Base.lproj/Main.storyboard
+++ b/Example/UPEmbeddedTextViewManager/Base.lproj/Main.storyboard
@@ -9,7 +9,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="UPEmbeddedTextViewManager_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="BYZ-38-t0r" customClass="ViewController" customModule="UPEmbeddedTextViewManager_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="interactive" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="100" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="IxU-WY-D1p">
-                                <rect key="frame" x="0.0" y="20" width="600" height="600"/>
+                                <rect key="frame" x="0.0" y="20" width="600" height="580"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="testCell" id="jLp-Tt-rCU" customClass="TestCellTableViewCell" customModule="UPEmbeddedTextViewManager_Example" customModuleProvider="target">
@@ -58,7 +58,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="centerX" secondItem="IxU-WY-D1p" secondAttribute="centerX" id="80P-pu-7mP"/>
-                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="IxU-WY-D1p" secondAttribute="bottom" constant="-20" id="j6g-sU-gcK"/>
+                            <constraint firstItem="wfy-db-euE" firstAttribute="top" secondItem="IxU-WY-D1p" secondAttribute="bottom" id="j6g-sU-gcK"/>
                             <constraint firstAttribute="width" secondItem="IxU-WY-D1p" secondAttribute="width" id="ksu-2B-dVj"/>
                             <constraint firstItem="IxU-WY-D1p" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="lcV-cO-GmM"/>
                         </constraints>

--- a/Pod/Classes/UPManager.swift
+++ b/Pod/Classes/UPManager.swift
@@ -448,8 +448,11 @@ public class UPManager: NSObject, UITextViewDelegate {
             setTextViewPreviousSize(currentSize, textView: textView, indexPath: textViewIndexPath)
             if !CGSizeEqualToSize(currentSize, CGSizeZero)
             {
+                let currentOffset = tableView.contentOffset
                 self.tableView.beginUpdates()
                 self.tableView.endUpdates()
+                tableView.layer.removeAllAnimations()
+                tableView.setContentOffset(currentOffset, animated: false)
             }
         }
     }


### PR DESCRIPTION
…tomaticallyAdjustsScrollViewInsets" for the example app's view controller. We need to confirm the latter change effectively represents an issue for our feature, since in such case we would need to require our clients to watch out for it (or could we handle it??). And most importantly added behavior so that upon applying beginUpdates endUpdates on tableview, the contentOffset property of the tableview does not get reset.
